### PR TITLE
Add all .ipynb files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .*.swp
 .coverage
 .cache
+*.ipynb
 .ipynb_checkpoints
 *.egg-info
 MANIFEST


### PR DESCRIPTION
Using jupytext makes unnecessary to keep pushing the notebooks, so it's
better to ignore them and push them manually when it's necessary.