### PR TITLE
Run GitHub Actions only on PRs and pushes to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
-name: Python package
+name: test
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -8,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Prevent running GitHub Actions on every branch.
They will run only on PRs and any push to master.
Add Python 3.8 to the matrix.