### PR TITLE
Install the package in the environment file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,12 @@ FLAKE8_FILES=setup.py $(PROJECT) notebooks
 help:
 	@echo "Commands:"
 	@echo ""
-	@echo "  install   install in editable mode"
 	@echo "  test      run the test suite and report coverage"
 	@echo "  format    run black to automatically format the code"
 	@echo "  check     run code style and quality checks (black and flake8)"
 	@echo "  lint      run pylint for a deeper (and slower) quality check"
 	@echo "  clean     clean up build and generated files"
 	@echo ""
-
-install:
-	pip install --no-deps -e .
 
 test:
 	# Run a tmp folder to make sure the tests are run on the installed version

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,6 @@ dependencies:
     - black
     - pylint
     - flake8
+    # Install our package in editable mode
+    - pip:
+      - -e .


### PR DESCRIPTION
I always forget to run `make install`. Install the package in editable
mode from the `environment.yml` file so we don't have to do that
anymore. That's one less step for reviewers to forget as well.