### PR TITLE
Add a step size and line search to gradient boosting

### DIFF
--- a/notebooks/source_layouts/eql_iterative.py
+++ b/notebooks/source_layouts/eql_iterative.py
@@ -197,7 +197,11 @@ class EQLIterative(EQLHarmonic):
             )
             predicted[:] = 0
             predict_numba(
-                coordinates, points_chunk, coeffs_chunk, predicted, greens_func_cartesian
+                coordinates,
+                points_chunk,
+                coeffs_chunk,
+                predicted,
+                greens_func_cartesian,
             )
             if self.line_search:
                 step = np.sum(residue * predicted) / np.sum(predicted ** 2)


### PR DESCRIPTION
Find a multiplier that minimizes the fit between residuals and predicted data for the whole dataset.  

![eql-boost-line-search](https://user-images.githubusercontent.com/290082/98682744-2d5d8880-235c-11eb-99f2-dbfed91d98eb.png)

This removes steps in which the MSE increases and stabilizes the convergence a bit.

![linesearch](https://user-images.githubusercontent.com/290082/98683067-875e4e00-235c-11eb-885b-eb3e7971c405.png)

![linesearch-diff](https://user-images.githubusercontent.com/290082/98683071-875e4e00-235c-11eb-82ff-ee673f793379.png)

Difference is not big and the final result is similar:

![linesearch-effect-grid](https://user-images.githubusercontent.com/290082/98683061-85948a80-235c-11eb-839f-b02efec5e68a.png)

