### PR TITLE
Shorten and summarize basic EQL theory in methods

### DIFF
--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -246,7 +246,7 @@ These equations can also be expressed as
 \end{equation}
 
 \noindent where $\mathbf{d}$ is a column vector containing the $N$ predicted
-values of the observed field at the observation points ${\mathbf{p}_i}_{i=1}^N$,
+values of the observed field at the observation points,
 $\mathbf{c}$ is a column vector containing the $M$ coefficients $c_j$,
 and $\mathbf{A}$ is the $N \times M$ Jacobian matrix,
 whose elements are


### PR DESCRIPTION
I was a bit unsure about the explanations for the theory behind the equivalent layer that we were presenting. It felt a bit too short with some important parts missing about the upward continuation equation and Green's identities. But at the same time it was feeling too long for a paper (considering we already have to explain the gradient boosting scheme). So I figured it might be good to cheat and start from the Cordell 1992 and skip the deductions of why we can use 1/r. That's been done in books and we have the citation for Cordell so we don't have to repeat what's on there.

@santisoler I know I deleted a lot of text here but I think it might be good to not distract from the core of the paper. What do you think? Feel free to disagree or change anything that you think doesn't work.

I'll start on the inversion part in another PR.