### PR TITLE
Add a citation to the convolutional equivalent layer

### DIFF
--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -183,7 +183,7 @@ larger number of equivalent sources than the number of data points.
 Some achieve greater efficiency by restricting their applications
 specific data types \citep{siqueira2017},
 interpolating only on regular grids \citep{leao1989},
-or requiring already gridded data (CITE PINGA NEW PAPER),
+or requiring already gridded data \citep{takahashi2020},
 to name a few.
 Furthermore, many of the optimizations proposed are also complex to implement
 in a computer program, limiting their wider adoption.

--- a/manuscript/references.bib
+++ b/manuscript/references.bib
@@ -11,7 +11,7 @@
   pages = {L51--L59},
   author = {Yaoguo Li and Douglas W. Oldenburg},
   title = {Rapid construction of equivalent sources using wavelets},
-  journal = {{GEOPHYSICS}}
+  journal = {{Geophysics}}
 }
 
 @Article{jirigalatu2019,
@@ -25,7 +25,7 @@
   pages = {G75--G82},
   author = {J\"{o}rg Jirigalatu and  Ebbing},
   title = {A fast equivalent source method for airborne gravity gradient data},
-  journal = {{GEOPHYSICS}}
+  journal = {{Geophysics}}
 }
 
 @Article{leao1989,
@@ -39,7 +39,7 @@
   pages = {497--507},
   author = {Jorge W. D. Le{\~{a}}o and Jo{\~{a}}o B. C. Silva},
   title = {Discrete linear transformations of potential field data},
-  journal = {{GEOPHYSICS}}
+  journal = {{Geophysics}}
 }
 
 @Article{bouman2016,
@@ -66,13 +66,13 @@
   pages = {293--305},
   author = {W. H. F. Smith and P. Wessel},
   title = {Gridding with continuous curvature splines in tension},
-  journal = {{GEOPHYSICS}}
+  journal = {{Geophysics}}
 }
 
 @Article{hansen1993,
   author    = {R. O. Hansen},
   title     = {Interpretive gridding by anisotropic kriging},
-  journal   = {{GEOPHYSICS}},
+  journal   = {{Geophysics}},
   year      = {1993},
   volume    = {58},
   number    = {10},
@@ -421,7 +421,21 @@
 	pages = {375--385},
 	author = {R. R. B. von Frese and D. N. Ravat and W. J. Hinze and C. A. McGue},
 	title = {Improved inversion of geopotential field anomalies for lithospheric investigations},
-	journal = {{GEOPHYSICS}}
+	journal = {{Geophysics}}
+}
+
+@article{takahashi2020,
+  doi = {10.1190/geo2019-0826.1},
+  url = {https://doi.org/10.1190/geo2019-0826.1},
+  year = {2020},
+  month = nov,
+  publisher = {Society of Exploration Geophysicists},
+  volume = {85},
+  number = {6},
+  pages = {G129--G141},
+  author = {Diego Takahashi and Vanderlei C. Oliveira Jr. and Val{\'{e}}ria C. F. Barbosa},
+  title = {Convolutional equivalent layer for gravity data processing},
+  journal = {{Geophysics}}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
This was the latest paper on EQL by the Pinga group and we were missing the citation in the introduction.