### PR TITLE
Remove the difference between RMS errors from conclusions

### DIFF
--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -1321,9 +1321,8 @@ memory needed to estimate source coefficients, making it possible to
 interpolate large datasets with millions of points that would otherwise produce
 Jacobian matrices larger than the available memory.
 The interpolations obtained though this new method achieve close to the same
-accuracy than the regular equivalent sources (within approximately 40\%), while
-reducing the computation time needed to estimate the source coefficients by
-approximately three times.
+accuracy than the regular equivalent sources, while reducing the computation
+time needed to estimate the source coefficients by approximately three times.
 We also show that an overlap of 50\% between adjacent windows achieves a good
 compromise between accuracy and computation time.
 The size of the overlapping windows should be chosen as the maximum value


### PR DESCRIPTION
The 40% that was being mentioned in the conclusions was out of context and
could be misleading. That number actually represents the difference between the
RMS errors of the gradient-boosted eqls and the non-boosted eqls. But without
context, it can be interpreted as the relative error of the method, which would
mean that it's not accurate at all. I think it's well explained on the results
section, so I just removed it from the conclusions.
