### PR TITLE
Add word-count to manuscript Makefile

### DIFF
--- a/manuscript/Makefile
+++ b/manuscript/Makefile
@@ -22,10 +22,8 @@ gji: $(OUTPUT_GJI)
 clean:
 	rm -rf $(OUTDIR)
 
-count:
+word-count:
 	texcount -merge $(PROJECT).tex
-
-count-gji:
 	texcount -merge $(GJI).tex
 
 show: all


### PR DESCRIPTION
Add a `word-count` target to `manuscript/Makefile` to count words and
figures in preprint and GJI manscript using `texcount`.