### PR TITLE
Move GJI keywords to variables.tex

### DIFF
--- a/manuscript/Makefile
+++ b/manuscript/Makefile
@@ -2,7 +2,7 @@
 PREPRINT = preprint
 GJI = gji
 # List other .tex needed files
-TEX_FILES = variables.tex content.tex appendix.tex keywords.tex abstract.tex references.bib
+TEX_FILES = variables.tex content.tex appendix.tex abstract.tex references.bib
 RESULTS = results/australia.tex results/best-parameters-airborne-survey.tex results/best-parameters-ground-survey.tex results/boost-overlapping.tex results/parameters-airborne-survey.tex results/parameters-ground-survey.tex results/source-layouts-schematics.tex results/synthetic-surveys.tex
 # Folder where output will be placed
 OUTDIR = _output

--- a/manuscript/gji.tex
+++ b/manuscript/gji.tex
@@ -49,7 +49,7 @@
 \end{summary}
 
 \begin{keywords}
-    \input{keywords}
+    \keywordsGJI{}
 \end{keywords}
 
 

--- a/manuscript/keywords.tex
+++ b/manuscript/keywords.tex
@@ -1,6 +1,0 @@
-Gravity anomalies and Earth structure;
-Magnetic anomalies: modelling and interpretation;
-Geopotential theory;
-Inverse theory;
-Statistical methods;
-Australia

--- a/manuscript/variables.tex
+++ b/manuscript/variables.tex
@@ -23,6 +23,16 @@
     \href{https://doi.org/xxx.xxx/xxxxxx}{doi.org/xxx.xxx/xxxxxx}
 }
 
+% Keywords for GJI
+\newcommand{\keywordsGJI}{%
+Gravity anomalies and Earth structure;
+Magnetic anomalies: modelling and interpretation;
+Geopotential theory;
+Inverse theory;
+Statistical methods;
+Australia.
+}
+
 % Define inverse symbol with shorter minus
 \newcommand{\inv}{^{\text{-}1}}
 \newcommand{\trans}{^{\text{T}}}


### PR DESCRIPTION
Move keywords for GJI manuscript from their own `.tex` file to `variables.tex`.
Remove the old `keywords.tex` from `Makefile` as a requirement for building the manuscript.