### PR TITLE
Pin Harmonica=0.2.1 and Verde=1.6.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,8 @@ dependencies:
   - boule=0.2.0
   - pooch=1.2.0
   - pygmt=0.2.1
+  - harmonica=0.2.1
+  - verde=1.6.1
   - pyproj
   - netcdf4
   - matplotlib
@@ -26,7 +28,3 @@ dependencies:
   - pylint
   - flake8
   - flake8-bugbear
-  - pip:
-      - git+https://github.com/fatiando/harmonica@master
-  - pip:
-      - git+https://github.com/fatiando/verde@master

--- a/notebooks/boost_and_layouts/eql_boost.py
+++ b/notebooks/boost_and_layouts/eql_boost.py
@@ -8,7 +8,7 @@ from sklearn.utils import shuffle
 from harmonica import EQLHarmonic
 
 from harmonica.equivalent_layer.harmonic import greens_func_cartesian
-from harmonica.equivalent_layer.utils import predict_numba
+from harmonica.equivalent_layer.utils import predict_numba_parallel
 
 
 class EQLHarmonicBoost(EQLHarmonic):
@@ -206,7 +206,7 @@ class EQLHarmonicBoost(EQLHarmonic):
                 copy_jacobian=True,
             )
             predicted[:] = 0
-            predict_numba(
+            predict_numba_parallel(
                 coordinates,
                 points_chunk,
                 coeffs_chunk,


### PR DESCRIPTION
Replaces `predict_numba` for `predict_numba_parallel` while importing from Harmonica.

Fixes #73 